### PR TITLE
Implement updating URL for browser navbar in loading/error substate

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,9 @@ module.exports = {
   env: {
     browser: true,
   },
-  rules: {},
+  rules: {
+    '@typescript-eslint/no-empty-function': 'off',
+  },
   overrides: [
     // node files
     {

--- a/addon/locations/hash.ts
+++ b/addon/locations/hash.ts
@@ -1,0 +1,22 @@
+import HashLocation from '@ember/routing/hash-location';
+import { inject as service } from '@ember/service';
+import RouterTransitionAnalyzerService from 'ember-refined-route-substate-url/services/router-transition-analyzer';
+
+export default class UpdateUrlEagerlyHashLocation extends HashLocation {
+  @service('router-transition-analyzer')
+  analyzer!: RouterTransitionAnalyzerService;
+
+  constructor(...args: []) {
+    super(...args);
+    this.analyzer.onShouldUpdateURL(this.shouldUpdateURL);
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    this.analyzer.offShouldUpdateURL(this.shouldUpdateURL);
+  }
+
+  private shouldUpdateURL = (path: string) => {
+    this.setURL(path);
+  };
+}

--- a/addon/locations/history.ts
+++ b/addon/locations/history.ts
@@ -1,0 +1,56 @@
+import HistoryLocation from '@ember/routing/history-location';
+import { inject as service } from '@ember/service';
+import RouterTransitionAnalyzerService from 'ember-refined-route-substate-url/services/router-transition-analyzer';
+
+/**
+ * We are overriding HistoryLocation https://api.emberjs.com/ember/3.28/classes/HistoryLocation
+ *
+ * Which is powering HistoryAPI based routing.
+ *
+ * Since we push "middle state" eagerly for destination route URLs, we need to force
+ * replaceState for those states, so user would not get "double back button" behaviour.
+ *
+ * It's quite clever trick in itself, should be relatively safe from runtime perspective,
+ * as we only do replaceState instead of pushState if previous history state has special flag.
+ */
+
+export default class UpdateUrlEagerlyHistoryLocation extends HistoryLocation {
+  @service('router-transition-analyzer')
+  analyzer!: RouterTransitionAnalyzerService;
+
+  private get historyStateKey() {
+    return 'history_location_update_url_eagerly_to_destination_route';
+  }
+
+  constructor(...args: []) {
+    super(...args);
+    this.analyzer.onShouldUpdateURL(this.shouldUpdateURL);
+  }
+
+  setURL(path: string) {
+    if (
+      this.history.state &&
+      this.history.state[this.historyStateKey] === true
+    ) {
+      super.replaceURL(path);
+      return;
+    }
+    super.setURL(path);
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    this.analyzer.offShouldUpdateURL(this.shouldUpdateURL);
+  }
+
+  private shouldUpdateURL = (path: string) => {
+    if (this.getURL() === path) {
+      return;
+    }
+    this.history.pushState(
+      { [this.historyStateKey]: true, early_update_path: path },
+      '',
+      path
+    );
+  };
+}

--- a/addon/services/router-transition-analyzer.ts
+++ b/addon/services/router-transition-analyzer.ts
@@ -1,0 +1,157 @@
+import Service from '@ember/service';
+import RouteInfo from '@ember/routing/-private/route-info';
+import Transition from '@ember/routing/-private/transition';
+import RouterService from '@ember/routing/router-service';
+import { inject as service } from '@ember/service';
+import { debug } from '@ember/debug';
+
+enum SUBSTATE_ROUTE_SUFFIX {
+  LOADING = 'loading',
+  ERROR = 'error',
+}
+
+export type ShouldUpdateURLCallback = (path: string) => void;
+
+const LOG_TAG = '[RouterTransitionAnalyzer]';
+
+export default class RouterTransitionAnalyzerService extends Service {
+  @service('router')
+  router!: RouterService;
+
+  private shouldUpdateURLCallbacks: ShouldUpdateURLCallback[] = [];
+  private transitionQueue: Transition[] = [];
+
+  constructor(...args: []) {
+    super(...args);
+    this.router.on('routeWillChange', this.routeWillChangeHandler);
+    this.router.on('routeDidChange', this.routeDidChangeHandler);
+  }
+
+  public onShouldUpdateURL(callbackToAdd: ShouldUpdateURLCallback): void {
+    this.shouldUpdateURLCallbacks.push(callbackToAdd);
+  }
+
+  public offShouldUpdateURL(callbackToRemove: ShouldUpdateURLCallback): void {
+    this.shouldUpdateURLCallbacks = this.shouldUpdateURLCallbacks.filter(
+      (cb) => {
+        return cb !== callbackToRemove;
+      }
+    );
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - "off" method actually exists, @types package is not correct
+    this.router.off('routeWillChange', this.routeWillChangeHandler);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.router.off('routeDidChange', this.routeDidChangeHandler);
+    this.shouldUpdateURLCallbacks = [];
+    this.transitionQueue = [];
+  }
+
+  private routeWillChangeHandler = (transition: Transition) => {
+    if (!this.hasRouteInfoForAnalysis(transition)) {
+      return;
+    }
+    debug(`${LOG_TAG}: routeWillChange -> ${transition.to.name}`);
+    this.transitionQueue.push(transition);
+
+    const newUrl = this.determineUrlForDestinationRoute(transition);
+    if (newUrl) {
+      debug(`${LOG_TAG}: shouldUpdateCallback -> ${newUrl}`);
+      this.shouldUpdateURLCallbacks.forEach((cb) => {
+        cb(newUrl);
+      });
+    }
+  };
+
+  private routeDidChangeHandler = (transition: Transition) => {
+    this.transitionQueue = [];
+
+    if (!this.hasRouteInfoForAnalysis(transition)) {
+      return;
+    }
+    debug(`${LOG_TAG}: routeDidChange -> ${transition.to.name}`);
+  };
+
+  private determineUrlForDestinationRoute(
+    transition: Transition
+  ): string | null {
+    if (!this.isIntermediateRoute(transition)) {
+      return null;
+    }
+
+    // These fail-safes here should never be triggered but just to be double sure that our queue is not messed up.
+    // We have those sanity checks to avoid possible TypeErrors.
+    const substateTransitionIndexInQueue =
+      this.transitionQueue.indexOf(transition);
+    if (substateTransitionIndexInQueue <= 0) {
+      return null;
+    }
+    const routeBeforeIntermediateRoute =
+      this.transitionQueue[substateTransitionIndexInQueue - 1];
+    if (!routeBeforeIntermediateRoute) {
+      return null;
+    }
+
+    // Transition queue can include: "my.route, my.route.loading, my.route.error" transitions
+    // Since for the first "my.route.loading" route we already triggered shouldUpdateUrlCallbacks
+    // We bail out for error route ones, this avoids updating url to "my/route/loading".
+    if (this.isIntermediateRoute(routeBeforeIntermediateRoute)) {
+      return null;
+    }
+    const params = this.findAllRouteParamsForUrlLookup(
+      routeBeforeIntermediateRoute
+    );
+    return this.router.urlFor.apply(this.router, [
+      routeBeforeIntermediateRoute.to.name,
+      ...params,
+    ]);
+  }
+
+  // We need to collect all parent routes params, like
+  // /route1/:id/route2/:id
+  // So we can call router.urlFor() to give us new destination route URL which we can push
+  private findAllRouteParamsForUrlLookup(transition: Transition) {
+    let route: RouteInfo | null = transition.to;
+    const params: RouteInfo['params'][] = [];
+    const finalParams: Array<string | undefined> = [];
+    while (route) {
+      const keys = Object.keys(route.params);
+      if (keys.length > 0) {
+        params.push(route.params);
+      }
+      route = route.parent;
+    }
+    params.map((obj) => {
+      const keys = Object.keys(obj);
+      keys.forEach((key: string) => {
+        finalParams.push(obj[key]);
+      });
+    });
+
+    finalParams.reverse();
+    return finalParams;
+  }
+
+  private isIntermediateRoute(transition: Transition): boolean {
+    const routeName = transition.to.name;
+    return (
+      routeName.endsWith(SUBSTATE_ROUTE_SUFFIX.LOADING) ||
+      routeName.endsWith(SUBSTATE_ROUTE_SUFFIX.ERROR)
+    );
+  }
+
+  private hasRouteInfoForAnalysis(transition: Transition): boolean {
+    return !!transition.to;
+  }
+}
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your services.
+declare module '@ember/service' {
+  interface Registry {
+    'router-transition-analyzer': RouterTransitionAnalyzerService;
+  }
+}

--- a/app/locations/hash.js
+++ b/app/locations/hash.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-refined-route-substate-url/locations/hash';

--- a/app/locations/history.js
+++ b/app/locations/history.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-refined-route-substate-url/locations/history';

--- a/app/services/router-transition-analyzer.js
+++ b/app/services/router-transition-analyzer.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-refined-route-substate-url/services/router-transition-analyzer';

--- a/tests/acceptance/router-transition-analyzer-test.ts
+++ b/tests/acceptance/router-transition-analyzer-test.ts
@@ -1,0 +1,224 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import RouterTransitionAnalyzerService from 'ember-refined-route-substate-url/services/router-transition-analyzer';
+import Route from '@ember/routing/route';
+import Router from 'dummy/router';
+import { hbs } from 'ember-cli-htmlbars';
+import { visit } from '@ember/test-helpers';
+
+type TestContext = import('ember-test-helpers').TestContext;
+
+module('Acceptance | router transition analyzer', function (hooks) {
+  setupApplicationTest(hooks);
+
+  module('shouldUpdateCallback', function () {
+    test('is not called when route has no loading template', async function (assert) {
+      const service: RouterTransitionAnalyzerService = this.owner.lookup(
+        'service:router-transition-analyzer'
+      );
+      service.onShouldUpdateURL((path) => {
+        assert.step(`onShouldUpdateURL: ${path}`);
+      });
+
+      setupRoute(this.owner, {
+        route: {
+          name: 'my/route',
+          model() {
+            return new Promise((resolve) => setTimeout(resolve, 25));
+          },
+        },
+        setupRouter(router) {
+          router.map(function () {
+            this.route('my', function () {
+              this.route('route');
+            });
+          });
+        },
+      });
+
+      await visit('my/route');
+      assert.verifySteps([]);
+    });
+
+    test('is called when route has loading template', async function (assert) {
+      const service: RouterTransitionAnalyzerService = this.owner.lookup(
+        'service:router-transition-analyzer'
+      );
+      service.onShouldUpdateURL((path) => {
+        assert.step(`onShouldUpdateURL: ${path}`);
+      });
+
+      setupRoute(this.owner, {
+        route: {
+          name: 'my/route',
+          model() {
+            return new Promise((resolve) => setTimeout(resolve, 25));
+          },
+        },
+        setupRouter(router) {
+          router.map(function () {
+            this.route('my', function () {
+              this.route('route');
+            });
+          });
+        },
+        templates: ['my/loading'],
+      });
+
+      await visit('my/route');
+      assert.verifySteps(['onShouldUpdateURL: /my/route']);
+    });
+
+    test('is called when route has error', async function (assert) {
+      const service: RouterTransitionAnalyzerService = this.owner.lookup(
+        'service:router-transition-analyzer'
+      );
+      service.onShouldUpdateURL((path) => {
+        assert.step(`onShouldUpdateURL: ${path}`);
+      });
+
+      setupRoute(this.owner, {
+        route: {
+          name: 'my/route',
+          model() {
+            return Promise.reject();
+          },
+        },
+        setupRouter(router) {
+          router.map(function () {
+            this.route('my', function () {
+              this.route('route');
+            });
+          });
+        },
+        templates: ['my/error'],
+      });
+
+      await visit('my/route');
+      assert.verifySteps(['onShouldUpdateURL: /my/route']);
+    });
+
+    test('is called once when route has loading -> error transition', async function (assert) {
+      const service: RouterTransitionAnalyzerService = this.owner.lookup(
+        'service:router-transition-analyzer'
+      );
+      service.onShouldUpdateURL((path) => {
+        assert.step(`onShouldUpdateURL: ${path}`);
+      });
+
+      setupRoute(this.owner, {
+        route: {
+          name: 'my/route',
+          model() {
+            return new Promise((_resolve, reject) => setTimeout(reject, 25));
+          },
+        },
+        setupRouter(router) {
+          router.map(function () {
+            this.route('my', function () {
+              this.route('route');
+            });
+          });
+        },
+        templates: ['my/loading', 'my/error'],
+      });
+
+      await visit('my/route');
+      assert.verifySteps(['onShouldUpdateURL: /my/route']);
+    });
+
+    test('route URL parameters are preserved', async function (assert) {
+      const service: RouterTransitionAnalyzerService = this.owner.lookup(
+        'service:router-transition-analyzer'
+      );
+      service.onShouldUpdateURL((path) => {
+        assert.step(`onShouldUpdateURL: ${path}`);
+      });
+
+      setupRoute(this.owner, {
+        route: {
+          name: 'params/child',
+          model() {
+            return new Promise((resolve) => setTimeout(resolve, 25));
+          },
+        },
+        setupRouter(router) {
+          router.map(function () {
+            this.route('params', { path: '/some-route/:param' }, function () {
+              this.route('child');
+            });
+          });
+        },
+        templates: ['params/loading'],
+      });
+
+      await visit('/some-route/my-param/child');
+      assert.verifySteps(['onShouldUpdateURL: /some-route/my-param/child']);
+    });
+  });
+
+  module('handling on/offShouldUpdateURL', function () {
+    test('shouldUpdateURL callback should not be called', async function (assert) {
+      const service: RouterTransitionAnalyzerService = this.owner.lookup(
+        'service:router-transition-analyzer'
+      );
+      const handler = () => {
+        assert.step('should not be called');
+      };
+      service.onShouldUpdateURL(handler);
+      service.offShouldUpdateURL(handler);
+
+      Router.map(function () {
+        this.route('my', function () {
+          this.route('route');
+        });
+      });
+
+      setupRoute(this.owner, {
+        route: {
+          name: 'my/route',
+          model() {
+            return new Promise((resolve) => setTimeout(resolve, 25));
+          },
+        },
+        setupRouter(router) {
+          router.map(function () {
+            this.route('my', function () {
+              this.route('route');
+            });
+          });
+        },
+        templates: ['my/loading'],
+      });
+
+      await visit('my/route');
+      assert.verifySteps([]);
+    });
+  });
+});
+
+function setupRoute(
+  owner: TestContext['owner'],
+  setup: {
+    route: {
+      name: string;
+      model: () => Promise<void>;
+    };
+    setupRouter: (router: typeof Router) => void;
+    templates?: string[];
+  }
+) {
+  setup.setupRouter(Router);
+  owner.register(
+    `route:${setup.route.name}`,
+    class MyRoute extends Route {
+      model() {
+        return setup.route.model();
+      }
+    }
+  );
+
+  setup.templates?.forEach((template) => {
+    owner.register(`template:${template}`, hbs``);
+  });
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,5 +6,4 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 Router.map(function () {});

--- a/tests/unit/locations/hash-test.ts
+++ b/tests/unit/locations/hash-test.ts
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import { ShouldUpdateURLCallback } from 'ember-refined-route-substate-url/services/router-transition-analyzer';
+import UpdateUrlEagerlyHashLocation from 'dummy/locations/hash';
+
+module('Unit | Location | hash', function (hooks) {
+  setupTest(hooks);
+
+  test('should handle URL update with shouldUpdateURL', async function (assert) {
+    class StubHashLocation extends UpdateUrlEagerlyHashLocation {
+      setURL(path: string) {
+        assert.step(`setURL: ${path}`);
+      }
+    }
+
+    class StubRouterTransitionAnalyzer extends Service {
+      private onShouldUpdateURLCallbacks: ShouldUpdateURLCallback[] = [];
+      onShouldUpdateURL(cb: ShouldUpdateURLCallback) {
+        this.onShouldUpdateURLCallbacks.push(cb);
+      }
+      offShouldUpdateURL() {}
+      triggerShouldUpdateURL(path: string) {
+        this.onShouldUpdateURLCallbacks.forEach((cb) => {
+          cb(path);
+        });
+      }
+    }
+    this.owner.register(
+      'service:router-transition-analyzer',
+      StubRouterTransitionAnalyzer
+    );
+    this.owner.register('location:hash', StubHashLocation);
+
+    const service: StubRouterTransitionAnalyzer = this.owner.lookup(
+      'service:router-transition-analyzer'
+    );
+    this.owner.lookup('location:hash');
+
+    service.triggerShouldUpdateURL('/my/new/url');
+
+    assert.verifySteps(['setURL: /my/new/url']);
+  });
+});

--- a/tests/unit/locations/history-test.ts
+++ b/tests/unit/locations/history-test.ts
@@ -1,0 +1,123 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import { ShouldUpdateURLCallback } from 'ember-refined-route-substate-url/services/router-transition-analyzer';
+import UpdateUrlEagerlyHistoryLocation from 'dummy/locations/history';
+
+module('Unit | Location | history', function (hooks) {
+  setupTest(hooks);
+
+  test('should handle URL update with shouldUpdateURL', async function (assert) {
+    const history = new FakeHistory();
+
+    class StubHistoryLocation extends UpdateUrlEagerlyHistoryLocation {
+      history = history;
+    }
+
+    class StubRouterTransitionAnalyzer extends Service {
+      private onShouldUpdateURLCallbacks: ShouldUpdateURLCallback[] = [];
+      onShouldUpdateURL(cb: ShouldUpdateURLCallback) {
+        this.onShouldUpdateURLCallbacks.push(cb);
+      }
+      offShouldUpdateURL() {}
+      triggerShouldUpdateURL(path: string) {
+        this.onShouldUpdateURLCallbacks.forEach((cb) => {
+          cb(path);
+        });
+      }
+    }
+    this.owner.register(
+      'service:router-transition-analyzer',
+      StubRouterTransitionAnalyzer
+    );
+    this.owner.register('location:history', StubHistoryLocation);
+
+    const service: StubRouterTransitionAnalyzer = this.owner.lookup(
+      'service:router-transition-analyzer'
+    );
+    const historyLocation: StubHistoryLocation =
+      this.owner.lookup('location:history');
+
+    service.triggerShouldUpdateURL('/my/new/url');
+
+    assert.deepEqual(
+      history.state,
+      {
+        history_location_update_url_eagerly_to_destination_route: true,
+        early_update_path: '/my/new/url',
+      },
+      'new state should be'
+    );
+    assert.equal(
+      history.length,
+      1,
+      'After pushing new state, length should be 1'
+    );
+
+    historyLocation.setURL('/my/new/url');
+    assert.equal(
+      history.length,
+      1,
+      'After router calls setURL when transition finishes, previous state should be replaced'
+    );
+  });
+
+  test('should not push new state if URL matches', async function (assert) {
+    const history = new FakeHistory();
+
+    class StubHistoryLocation extends UpdateUrlEagerlyHistoryLocation {
+      history = history;
+      getURL() {
+        return '/my/new/url';
+      }
+    }
+
+    class StubRouterTransitionAnalyzer extends Service {
+      private onShouldUpdateURLCallbacks: ShouldUpdateURLCallback[] = [];
+      onShouldUpdateURL(cb: ShouldUpdateURLCallback) {
+        this.onShouldUpdateURLCallbacks.push(cb);
+      }
+      offShouldUpdateURL() {}
+      triggerShouldUpdateURL(path: string) {
+        this.onShouldUpdateURLCallbacks.forEach((cb) => {
+          cb(path);
+        });
+      }
+    }
+    this.owner.register(
+      'service:router-transition-analyzer',
+      StubRouterTransitionAnalyzer
+    );
+    this.owner.register('location:history', StubHistoryLocation);
+
+    const service: StubRouterTransitionAnalyzer = this.owner.lookup(
+      'service:router-transition-analyzer'
+    );
+    this.owner.lookup('location:history');
+
+    service.triggerShouldUpdateURL('/my/new/url');
+    assert.deepEqual(history.state, null, 'no state update should pushed');
+  });
+});
+
+class FakeHistory {
+  state: FakeHistoryState | null = null;
+  _states: FakeHistoryState[] = [];
+  replaceState(state: FakeHistoryState) {
+    this.state = state;
+    this._states[0] = state;
+  }
+  pushState(state: FakeHistoryState) {
+    this.state = state;
+    this._states.unshift(state);
+  }
+  back() {}
+  forward() {}
+  go() {}
+  scrollRestoration: ScrollRestoration = 'auto';
+  get length() {
+    return this._states.length;
+  }
+}
+
+type FakeHistoryState = Record<string, unknown>;

--- a/tests/unit/services/router-transition-analyzer-test.ts
+++ b/tests/unit/services/router-transition-analyzer-test.ts
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import RouterTransitionAnalyzerService from 'ember-refined-route-substate-url/services/router-transition-analyzer';
+
+module('Unit | Service | router-transition-analyzer', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', async function (assert) {
+    const service: RouterTransitionAnalyzerService = this.owner.lookup(
+      'service:router-transition-analyzer'
+    );
+    assert.ok(service);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noEmitOnError": true,
+    "noEmitOnError": false,
     "noEmit": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/types/@ember/routing/hash-location.d.ts
+++ b/types/@ember/routing/hash-location.d.ts
@@ -1,0 +1,8 @@
+import EmberObject from '@ember/object';
+
+declare module '@ember/routing/hash-location' {
+  // More info about interface over here - https://github.com/emberjs/ember.js/blob/v3.28.1/packages/%40ember/-internals/routing/lib/location/api.ts
+  export default class HashLocation extends EmberObject {
+    setURL(path: string): void;
+  }
+}

--- a/types/@ember/routing/history-location.d.ts
+++ b/types/@ember/routing/history-location.d.ts
@@ -1,0 +1,11 @@
+import EmberObject from '@ember/object';
+
+declare module '@ember/routing/history-location' {
+  // More info about interface over here - https://github.com/emberjs/ember.js/blob/v3.28.1/packages/%40ember/-internals/routing/lib/location/api.ts
+  export default class HistoryLocation extends EmberObject {
+    protected history: History;
+    replaceURL(url: string): void;
+    setURL(path: string): void;
+    getURL(): string;
+  }
+}


### PR DESCRIPTION
This PR implements updating URL on browser address bar eagerly for loading/error substates. 

Therefore application URL management feels more natural and user can reload the page from loading or error page for given destination route.